### PR TITLE
Recognize Fast Track Ultra 8R card

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ FTU-Mixer uses [wxPython](http://www.wxpython.org/) for the GUI and
 functionalities.
 
 FTU-Mixer has been developed and tested with an ordinary (non 8R) M-Audio Fast
-Track Ultra. It should work with the Fast Track Ultra 8R, but that has not been
-tested.
+Track Ultra. The FTU-Mixer will also recognize, and work with, the Fast Track
+Ultra 8R, but that combination has not been thoroughly tested.
 
 
 ## Known issues

--- a/source/ftumixer.py
+++ b/source/ftumixer.py
@@ -617,11 +617,11 @@ if __name__ == "__main__":
 	card_index = None
 	i = 0
 	for c in alsaaudio.cards():
-		if c == "Ultra":
+		if c == "Ultra" or c == "F8R":
 			card_index = i
 		i += 1
 	if card_index is None:
-		print "No M-Audio Fast Track Ultra found. Exiting..."
+		print "No M-Audio Fast Track Ultra or Ultra 8R found. Exiting..."
 	else:
 		# parse command line arguments
 		parser = argparse.ArgumentParser(description="A little mixer for the M-Audio Fast Track Ultra audio interfaces.")


### PR DESCRIPTION
This change allows the FTU-mixer to also recognize, and work with, the M-Audio Fast Track
Ultra 8R audio interface.

Basic testing has been performed with an Ultra 8R:

- The master volume does control the level of Output 1 and Output 2 as expected.  (Except
  that the level decreases very quickly when moving the fader downwards from maximum.)
  (Tested with playback from the PC and headphones in headphone output 1, which equals output
  1 and 2.)

- The OutX sliders works as expected, tested for all combinations of inputs AIn1, AIn2 and
  AIn6 to outputs Out1 and Out2.
  (Tested with a microhone in inputs 1,2 and 6, and headphones in headphone 1 ouput.)

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@ntebb.no>

@JonasSC Thanks for creating this mixer - I am very happy that I found it!
Asbjørn